### PR TITLE
Update to the fr_CA manual following OJS 3.3 release

### DIFF
--- a/fr/README.md
+++ b/fr/README.md
@@ -1,4 +1,4 @@
-# Guide de l'utilisateur ou de l'utilisatrice OJS 3.2
+# Guide de l'utilisateur ou de l'utilisatrice OJS 3.3
 
 Ce guide vous aidera à publier des journaux et revues sur Open Journal Systems (OJS).
 
@@ -6,7 +6,7 @@ Il offre une introduction à chaque étape du flux des travaux, de la soumission
 
 En cliquant sur le lien **Aide** visible dans l’application, vous découvrirez un panneau avec les informations les plus utiles pour la section. 
 
-Une description plus détaillée de ce logiciel est disponible sur [Learning OJS 3](https://docs.pkp.sfu.ca/learning-ojs/en/) (en anglais).
+Une description plus détaillée de ce logiciel est disponible sur [Apprendre OJS 3: Un guide visuel de Open Journal Systems](https://docs.pkp.sfu.ca/learning-ojs/fr/).
 
 --
 

--- a/fr/SUMMARY.md
+++ b/fr/SUMMARY.md
@@ -10,6 +10,7 @@
 	* [Évaluation](editorial-workflow/review)
 	* [Révision](editorial-workflow/copyediting)
 	* [Production](editorial-workflow/production)
+	* [Publication](editorial-workflow/publication)	
 * [Gestion des numéros](issue-management)
 * [Tâches](tasks)
 * Paramètres

--- a/fr/administration.md
+++ b/fr/administration.md
@@ -3,7 +3,7 @@
 1. [Revues hébergées](administration#hosted-journals)
 1. [Fonctions administratives](administration#admin-functions)
  
-L’administration du site est réservée aux utilisateurs et utilisatrices disposant des autorisations complètes. Les tâches administratives sont peu fréquentes et peuvent être assurées par un ou une gestionnaire de revue, un rédacteur ou une rédactrice en chef ou une administratrice ou un administrateur désigné. Pour plus d'informations, veuillez consulter  [Learning OJS: Site Administration](https://docs.pkp.sfu.ca/learning-ojs/en/site-administration) (en anglais).
+L’administration du site est réservée aux utilisateurs et utilisatrices disposant des autorisations complètes. Les tâches administratives sont peu fréquentes et peuvent être assurées par un ou une gestionnaire de revue, un rédacteur ou une rédactrice en chef ou une administratrice ou un administrateur désigné. Pour plus d'informations, veuillez consulter  [Apprendre OJS 3: Administration du site](https://docs.pkp.sfu.ca/learning-ojs/fr/site-administration).
 
 ## Revues hébergées
  

--- a/fr/authoring.md
+++ b/fr/authoring.md
@@ -5,7 +5,7 @@
 1. [Procéder à une soumission](authoring#make-submission)
 1. [Suivre une soumission](authoring#track-submission)
 
-Une fois connecté-e à l’OJS en tant qu’auteur ou auteure, vous verrez deux onglets : "Soumissions qui me sont assignées" et "Mes soumissions". Si vous n’avez jamais soumis d'article à cette revue, ces onglets seront vides. Pour plus d'informations, consultez [Learning OJS 3: Authoring](https://docs.pkp.sfu.ca/learning-ojs/en/authoring) (en anglais)
+Une fois connecté-e à l’OJS en tant qu’auteur ou auteure, vous verrez deux onglets : "Soumissions qui me sont assignées" et "Mes soumissions". Si vous n’avez jamais soumis d'article à cette revue, ces onglets seront vides. Pour plus d'informations, consultez [Apprendre OJS 3: Soumission](https://docs.pkp.sfu.ca/learning-ojs/fr/authoring).
 
 ## <a name="author-actions"></a>Actions de l’auteur ou de l’auteure
 À la droite de votre écran, cliquez sur « Nouvelle soumission » pour démarrer une nouvelle soumission.
@@ -27,15 +27,11 @@ Faire une nouvelle soumission est une procédure en 5 étapes faciles à suivre.
 
 Téléverser vos fichiers de soumissions.
 
-**Téléverser un fichier** : afin de faciliter l'organisation des fichiers pour les projets de grande envergure, chaque fichier doit être ajouté en tant que composant individuel.
+**Téléverser un fichier** :
 
-Vous téléverserez vos fichiers un par un. Vous aurez l’opportunité de téléverser plus de fichiers à un moment ultérieur.
+Vous pouvez téléverser plusieurs fichiers avec votre soumission, soit en sélectionnant plusieurs fichiers simultanément, soit en les téléversant individuellement.
 
-**Ajouter des détails** :
-
-Si vous le souhaitez, utilisez le lien « Modifier » pour changer le nom de fichier choisi par défaut par le système.
-
-**Terminer** : Ajoutez des fichiers additionnels ou cliquez sur « Terminer ».
+Il faut spécifier le type de chaque fichier. Les types possibles dépendent des options qui ont été paramétrées pour la revue, par exemple *texte de l'article*, *ensemble de données*, *résultats de recherche* ou *images*.
 
 Sélectionnez « Enregistrer et continuer » pour poursuivre vers la prochaine étape.
 

--- a/fr/editorial-workflow.md
+++ b/fr/editorial-workflow.md
@@ -6,40 +6,11 @@
 
 Le flux des travaux vous permet de faire passer une soumission à travers les phases d’évaluation initiale, de révision par les pairs, d’édition et de production, jusqu'au point où elle sera prête pour la publication.
 
-Chaque onglet de la page du flux des travaux vous offre des informations, outils et zones de discussions dont vous aurez besoin pour compléter les tâches nécessaires. Vous pourrez [ajouter des participants-es](editorial-workflow#participants) pertinents-es à chaque étape. Lorsque vous serez prêt-e, vous aurez à effectuer une série d'[actions éditoriales](editorial-workflow#editorial-actions) pour chaque étape. Pour plus d'informations, consultez [Learning OJS 3: Editorial Workflow](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow) (en anglais).
+Chaque onglet de la page du flux des travaux vous offre des informations, outils et zones de discussions dont vous aurez besoin pour compléter les tâches nécessaires. Vous pourrez [ajouter des participants-es](editorial-workflow#participants) pertinents-es à chaque étape. Lorsque vous serez prêt-e, vous aurez à effectuer une série d'[actions éditoriales](editorial-workflow#editorial-actions) pour chaque étape. Pour plus d'informations, consultez [Apprendre OJS 3: Flux des travaux éditoriaux](https://docs.pkp.sfu.ca/learning-ojs/fr/editorial-workflow).
 
-## <a name="manage-submission-details"></a>Gérer les détails d’une soumission
+Pour en apprendre davantage sur les différentes étapes du flux des travaux, veuillez consulter les sections suivantes:
 
-Les détails d’une soumission apparaissent en haut de la page. Dans cette zone, vous trouverez aussi des outils pour vous aider à gérer les métadonnées de la soumission et l’historique éditorial. Les données attachées à la soumission grâce à ces outils sont disponibles lors de toutes les étapes.
-
-### <a name="metadata"></a>Métadonnées
-
-La section « Métadonnées » inclut deux onglets : « Soumission » et « Identifiants ».
-
-« Soumission » inclut les métadonnées de la soumission, telles que le titre de l’article, le résumé, les contributeurs et contributrices et les mots-clés.
-
-« Identifiants » offre un espace pour ajouter tout identifiant URL public.
-
-### <a name="editorial-history"></a>Journal d'événements
-
-Consultez et annotez le registre de tous les évènements associés à une soumission. Le journal est uniquement accessible aux utilisateurs et utilisatrices ayant des droits éditorial ou administratif.
-
-### <a name="submission-library"></a>Bibliothèque
-
-Un dépôt rapide pour tout fichier que vous souhaiteriez associer à votre soumission. Cela est utile pour les fichiers qui ne sont spécifiques à aucune étape, tels que les contrats, les fichiers de marketing ou les directives que vous souhaiteriez partager avec les rédacteurs et rédactrices ou assistants et assistantes.
-
-Vous pouvez rapidement ajouter des fichiers depuis la [bibliothèque éditoriale](settings#workflow-library) en cliquant sur **Afficher la bibliothèque de documents**.
-
-## <a name="editorial-actions"></a>Actions éditoriales
-
-En haut de chaque étape du processus, vous verrez les actions éditoriales disponibles pour vous. Ces décisions évoluent à chaque étape. Dans la plupart des cas, elles complètent l’étape en cours et acheminent la soumission vers l’étape suivante.
-
-Consultez le [guide](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow) (en anglais) pour en apprendre plus sur les actions éditoriales propres à chaque étape.
-
-## <a name="participants"></a>Participants-es
-
-À la droite de chaque étape du processus, vous trouverez une liste des utilisateurs et utilisatrices ayant accès à cette étape. Vous pouvez ajouter des assistants et assistantes, des réviseurs et réviseures, des responsables de mise en page et d’autres utilisateurs et utilisatrices à qui vous souhaiteriez donner accès à l’étape en cours.
-
-*Quand vous ajoutez un utilisateur ou une utilisatrice, il aura accès à toutes les étapes autorisées dépendamment de son rôle.* Par exemple, un rédacteur ou une rédactrice aura accès à toutes les étapes, tandis qu’un réviseur ou une réviseure aura seulement accès à l’étape de la révision.
-
-*Vous n’avez pas besoin d’ajouter d’évaluateurs ou d'évaluatrices aux participants-es.* Lorsque vous atteignez l'[étape d’évaluation](editorial-workflow/review), vous pourrez gérer les évaluateurs et évaluatrices dans une fenêtre plus pratique.
+1. [Soumission](editorial-workflow/submission)
+1. [Évaluation](editorial-workflow/review)
+1. [Révision](editorial-workflow/copyediting)
+1. [Production](editorial-workflow/production)

--- a/fr/editorial-workflow/production.md
+++ b/fr/editorial-workflow/production.md
@@ -3,30 +3,26 @@
 1. [Orientation](production#orientation)
 1. [Publier une soumission](production#publish)
 
-Durant la phase de production, le rédacteur ou la rédactrice assigne des assistants et assistantes de production qui aideront à préparer les fichiers prêts à être publiés, connus sous le nom d'épreuves. Pour plus d'informations, consultez [Learning OJS 3: Production](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow#production).
+Durant la phase de production, le rédacteur ou la rédactrice assigne des assistants et assistantes de production qui aideront à préparer les fichiers prêts à être publiés, connus sous le nom d'épreuves. Pour plus d'informations, consultez [Apprendre OJS 3: Production](https://docs.pkp.sfu.ca/learning-ojs/fr/editorial-workflow#passer-%C3%A0-la-production).
 
 ## <a name="orientation"></a>Orientation
 
-L’étape de la production comporter trois sections.
+L’étape de la production comporter deux sections.
 
 ### <a name="production-ready"></a>Fichiers prêts pour la production
 
-Tous les fichiers sélectionnés pour la production apparaitront ici. Ceux-ci incluent généralement des fichiers qui ont été préparés durant l’étape de la [révision](copyediting). Les assistants-es de production pourront utiliser ces fichiers pour générer des formats finaux de production.
+Tous les fichiers sélectionnés pour la production apparaitront ici. Ceux-ci incluent généralement des fichiers qui ont été préparés durant l’étape de la [révision](copyediting). Les assistants et assistantes de production pourront utiliser ces fichiers pour générer des formats finaux de production.
 
 ### <a name="production-discussions"></a>Discussions sur la production
 
 Les rédacteurs et rédactrices et les assistants et assistantes de production peuvent utiliser cette section pour entamer des conversations, si des détails doivent être clarifiés avant la création des fichiers finaux de publication.
 
-### <a name="publication-formats"></a>Épreuves
-
-Les rédacteurs et rédactrices et les assistants et assistantes de production peuvent créer des épreuves et téléverser un fichier pour chaque épreuve. Chaque fichier se présente typiquement dans un format distinct, tel que PDF ou HTML.
-
 ### <a name="participants"></a>Participants-es
 
-Les éditeurs et éditrices peuvent ajouter des assistants et assistantes de production ou des responsables de mise en page dans ce panneau. [En savoir plus](../editorial-workflow#participants).
+Les rédacteurs et rédactrices peuvent ajouter des assistants et assistantes de production ou des responsables de mise en page dans ce panneau. [En savoir plus](../editorial-workflow#participants).
 
 ## <a name="publish"></a>Publier une soumission
 
-Une fois la soumission prête à être publiée, vous devez la programmer dans le cadre de la publication d’un numéro.
+Les rédacteurs et rédactrices et les assistants et assistantes de production peuvent créer des épreuves pour la publication. Ces épreuves représentent généralement différents formats de fichiers, tel que PDF ou HTML.
 
-Le bouton « Calendrier de publication » vous permet de sélectionner un numéro à venir, de fixer une date de publication, de joindre les autorisations de licence, et de paginer le document si désiré.
+Une fois les fichiers convertis en épreuves prêtes pour la publication, les éditeurs et éditrices peuvent se rendre à l'onglet Publication en cliquant sur le bouton Calendrier de publication. Les épreuves seront alors versées dans l'onglet Publication.

--- a/fr/editorial-workflow/publication.md
+++ b/fr/editorial-workflow/publication.md
@@ -1,0 +1,13 @@
+# Publication
+
+À partir de l'onglet Publication, le rédacteur ou la rédactrice peut réviser et modifier les métadonnées, téléverser des épreuves, définir ou modifier les autorisations, et assigner l'article à un numéro.
+
+# Créer une nouvelle version
+
+Le bouton Créer une nouvelle version (disponible après publication) permet de créer une copie exacte des épreuves et des métadonnées publiées.
+
+Il vous est alors possible de modifier et de publier ce contenu, sans changer le contenu préalablement publié. Toutes les versions seront préservées et accessibles publiquement, ainsi que dans l'onglet Publication.
+
+## Dépublier
+
+Dépublier un article le retirera du numéro auquel il a été assigné, et le rendra inaccessible au public.

--- a/fr/editorial-workflow/review.md
+++ b/fr/editorial-workflow/review.md
@@ -8,7 +8,7 @@ Durant l’étape de l'évaluation, le rédacteur ou la rédactrice assigne des 
 
 Une fois que les évaluateurs et évaluatrices ont soumis leurs évaluations et recommandations, le rédacteur ou la rédactrice doit décider si la soumission est prête à être révisée ou si elle requiert d’autres évaluations.
 
-Par défaut, les étapes d'évaluation démarrent au **Cycle 1**. Des cycles supplémentaires peuvent être lancés au besoin, par exemple si le rédacteur ou la rédactrice demande des révisions majeures. Pour plus d'informations, veuillez consulter [Learning OJS 3: Review](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow#review) (en anglais).
+Par défaut, les étapes d'évaluation démarrent au **Cycle 1**. Des cycles supplémentaires peuvent être lancés au besoin, par exemple si le rédacteur ou la rédactrice demande des révisions majeures. Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Évaluation](https://docs.pkp.sfu.ca/learning-ojs/fr/editorial-workflow#%C3%A9valuation).
 
 ## <a name="orientation"></a>Orientation
 
@@ -45,3 +45,4 @@ Le rédacteur ou la rédactrice peut lancer l’[étape de révision](copyeditin
 
 ### <a name="decline"></a>Refuser une soumission
 Le rédacteur ou la rédactrice peut refuser une soumission si elle ne passe pas l'évaluation. La soumission sera alors supprimée du flux des travaux et archivée.
+

--- a/fr/issue-management.md
+++ b/fr/issue-management.md
@@ -16,7 +16,8 @@ On peut accéder aux options de chaque numéro en utilisant la petite flèche à
 
 **Supprimer** – La suppression d'un numéro est définitive.
 
-Pour plus d'informations, veuillez consulter [Learning OJS 3: Issues](https://docs.pkp.sfu.ca/learning-ojs/en/issues) (en anglais).
+Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Production et Publication ](https://docs.pkp.sfu.ca/learning-ojs/fr/production-publication#cr%C3%A9er-un-num%C3%A9ro). 
+
 
 ## <a name="future-issues"></a>Numéros à venir
 

--- a/fr/reviewing.md
+++ b/fr/reviewing.md
@@ -4,7 +4,7 @@
 1. [Compléter une évaluation](reviewing#complete-review)
 1. [Compléter votre profil d’utilisateur-trice](reviewing#complete-user-profile)
 
-Les évaluateurs et évaluatrices jouent un rôle crucial en vue de garantir la qualité des publications académiques. Ce chapitre décrit le processus pour compléter une révision. Pour plus d'informations, consultez [Learning OJS 3: Reviewing](https://docs.pkp.sfu.ca/learning-ojs/en/reviewing) (en anglais)
+Les évaluateurs et évaluatrices jouent un rôle crucial en vue de garantir la qualité des publications académiques. Ce chapitre décrit le processus pour compléter une révision. Pour plus d'informations, consultez [Apprendre OJS 3: Évaluation](https://docs.pkp.sfu.ca/learning-ojs/fr/reviewing).
 
 ## <a name="sign-up"></a>S’inscrire comme évaluateur-trice 
 

--- a/fr/settings/distribution-settings.md
+++ b/fr/settings/distribution-settings.md
@@ -6,7 +6,7 @@
 1. [Accès](distribution-settings#access)
 1. [Archivage](distribution-settings#archiving)
 
-Dans les paramètres de la distribution, vous pouvez configurer comment les utilisateurs et utilisatrices découvrent, repèrent, utilisent et lisent le contenu de votre revue. Pour plus d'informations, veuillez consulter [Learning OJS 3: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution) (en anglais).
+Dans les paramètres de la distribution, vous pouvez configurer comment les utilisateurs et utilisatrices découvrent, repèrent, utilisent et lisent le contenu de votre revue. Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Paramètres de distribution](https://docs.pkp.sfu.ca/learning-ojs/fr/settings-distribution).
 
 ## <a name="license"></a>Licence
 Dans cet onglet, vous pouvez configurer le droit d'auteur et les droits d'utilisation au niveau de la revue. Vous pouvez également paramétrer ces droits au niveau de l'article lorsque vous publiez un article ou un numéro. 

--- a/fr/settings/journal-settings.md
+++ b/fr/settings/journal-settings.md
@@ -5,7 +5,7 @@
 1. [Rubriques de la revue](journal-settings#sections)
 1. [Catégories](journal-settings#categories)
 
-Les paramètres de revue permettent de configurer diverses informations, incluant l'équipe éditoriale, les coordonnées, les rubriques, et les catégories de contenus. Pour plus d'informations, veuillez consulter [Learning OJS 3: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup) (en anglais).
+Les paramètres de revue permettent de configurer diverses informations, incluant l'équipe éditoriale, les coordonnées, les rubriques, et les catégories de contenus. Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Paramètres de la revue](https://docs.pkp.sfu.ca/learning-ojs/fr/journal-setup).
 
 ## <a name="masthead"></a>Bloc générique
 Utilisez le bloc générique afin de saisir divers renseignements au sujet de votre revue. Certains de ces renseignements seront affichés automatiquement sur les pages Web de votre revue.

--- a/fr/settings/website-settings.md
+++ b/fr/settings/website-settings.md
@@ -4,7 +4,8 @@
 1. [Configuration](website-settings#setup)
 1. [Plugiciels](website-settings#plugins)
 
-Les paramètres du site Web permettent de configurer l'apparence et les informations de votre site Web public, ses paramètres linguistiques, ses paramètres d'archivage, et d'installer et activer des plugiciels. Pour plus d'informations, veuillez consulter [Learning OJS 3: Website Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website) (en anglais). Des onglets additionnels peuvent apparaître si vous avez activé certains plugiciels, tels que le Plugiciel de pages statiques.
+
+Les paramètres du site Web permettent de configurer l'apparence et les informations de votre site Web public, ses paramètres linguistiques, ses paramètres d'archivage, et d'installer et activer des plugiciels. Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Paramètres du site web](https://docs.pkp.sfu.ca/learning-ojs/fr/settings-website). Des onglets additionnels peuvent apparaître si vous avez activé certains plugiciels, tels que le Plugiciel de pages statiques.
 
 ## <a name="appearance"></a>Apparence
 Cet onglet permet de changer l'apparence du site Web de votre revue, de téléverser des images ou de choisir un thème.
@@ -38,6 +39,15 @@ Cette section permet de modifier les menus de navigation de votre site Web, en a
 
 ### Annonces
 Cette section permet de créer des annonces ou des types d'annonces qui seront affichées sur la page d'accueil votre site ou seront envoyées par courriel à l'ensemble de vos lecteurs et lectrices.
+
+### Listes
+Cette section permet de configurer combien d'éléments et de liens apparaissent dans une liste.
+
+### Déclaration de confidentialité
+Cette section permet de rédiger une déclaration qui explique de quelle manière seront utilisées les données soumises à votre revue et sur votre site.
+
+### Date et heure
+Cette section permet de configurer l'affichage de la date et de l'heure. Si votre revue est multilingue, chaque langue aura des paramètres différents. Pour changer les paramètres des autres langues, sélectionnez l'onglet correspondant.
 
 ## <a name="plugins"></a>Plugiciels
 Les plugiciels étendent les fonctionnalités d'OJS et lui permettent d'interagir avec des outils et services externes. Cet onglet permet d'activer ou de configurer vos plugiciels, ou d'en installer de nouveaux dans la **Galerie de plugiciels**.

--- a/fr/settings/workflow-settings.md
+++ b/fr/settings/workflow-settings.md
@@ -5,10 +5,13 @@
 1. [Bibliothèque de l'éditeur](workflow-settings#publisher)
 1. [Courriels](workflow-settings#emails)
 
-Cet onglet permet de configurer tous les aspects du [flux des travaux](../editorial-workflow), incluant la gestion des fichiers, les directives de soumission, les directives et dates butoirs d'évaluation, les courriels de notifications, et plus encore. Pour plus d'informations, veuillez consulter [Learning OJS 3 Workflow Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-workflow) (en anglais).
+Cet onglet permet de configurer tous les aspects du [flux des travaux](../editorial-workflow), incluant la gestion des fichiers, les directives de soumission, les directives et dates butoirs d'évaluation, les courriels de notifications, et plus encore. Pour plus d'informations, veuillez consulter [Apprendre OJS 3 : Paramètres du flux des travaux](https://docs.pkp.sfu.ca/learning-ojs/fr/settings-workflow).
 
 ## <a name="submission"></a>Soumission
 L'onglet Soumission permet de déterminer les éléments que les auteurs et auteures doivent fournir ou approuver lorsqu'ils ou elles font une soumission.
+
+### Désactiver les soumissions
+Cochez cette case si vous désirez désactiver les soumissions pour la revue au complet. Vous pouvez également désactiver les soumissions pour une section en particulier en cliquant sur le lien ***rubriques de revue***.
 
 ### Métadonnées
 Si vous activez un champ de métadonnée, il sera disponible pour chaque soumission. Lorsque vous cochez une métadonnée, vous permettez aux auteurs et auteures de l'ajouter au moment de faire une soumission. Autrement, seul un rédacteur ou une rédactrice pourra ajouter cette métadonnée.
@@ -48,3 +51,5 @@ Les éléments stockés dans la Bibliothèque de l'éditeur peuvent être rapide
 OJS envoie plusieurs courriels au cours des diverses étapes du [flux des travaux](../editorial-workflow) ou à l'occasion d'autres procédures, telles que l'enregistrement d'un utilisateur ou d'une utilisatrice ou l'accusé de réception d'une soumission. Les paramètres de cet onglet permettent de modifier la signature jointe à chaque courriel, ainsi que de changer les messages par défaut envoyés pour chaque type de courriel.
 
 Vous pouvez consulter et modifier le contenu de chaque courriel en cliquant sur la flèche située à sa droite.
+
+Cliquez sur **Filtres** afin de filter les modèles de courriels par destinateur, destinataire, étape de flux des travaux, ou en fonction du statut d'activation du modèle.

--- a/fr/submissions.md
+++ b/fr/submissions.md
@@ -13,7 +13,7 @@ Les utilisatrices et utilisateurs éditoriaux et administratifs ont accès à to
 
 ## <a name="new-submission"></a>Créer une nouvelle soumission
 
-Vous pouvez créer une nouvelle soumission en cliquant sur le bouton **Nouvelle soumission** qui apparaît au-dessus de chaque liste de soumissions. Pour plus d'informations, consultez [Learning OJS 3: Submitting an Article](https://docs.pkp.sfu.ca/learning-ojs/en/authoring#submitting-an-article) (en anglais).
+Vous pouvez créer une nouvelle soumission en cliquant sur le bouton **Nouvelle soumission** qui apparaît au-dessus de chaque liste de soumissions. Pour plus d'informations, consultez [Apprendre OJS 3: Soumettre un article](https://docs.pkp.sfu.ca/learning-ojs/fr/authoring#soumettre-un-article).
 
 ## <a name="my-queue"></a>Mes soumissions
 
@@ -27,7 +27,7 @@ Les gestionnaires de la revue peuvent visualiser toute soumission qui n’a pas 
 
 ## <a name="active"></a>Actives (toutes)
 
-Vous trouverez ici toute soumission qui n’a pas été publiée ou a été refusée. Seuls les utilisatrices et utilisateurs administratifs et éditoriaux ont accès à cet onglet. Pour plus d'informations, consultez [Learning OJS 3: Submissions](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow#submission) (en anglais).
+Vous trouverez ici toute soumission qui n’a pas été publiée ou a été refusée. Seuls les utilisatrices et utilisateurs administratifs et éditoriaux ont accès à cet onglet. Pour plus d'informations, consultez [Apprendre OJS 3: Tableau de bord de soumissions](https://docs.pkp.sfu.ca/learning-ojs/fr/editorial-workflow#tableau-de-bord-de-soumission).
 
 ## <a name="archives"></a>Archives
 
@@ -41,4 +41,4 @@ Utilisez la barre de recherche au-dessus de la liste pour localiser des soumissi
 
 ### Filtrer des listes volumineuses
 
-Cliquez sur le bouton **Filtres** pour déployer l’ensemble des filtres de recherche. Vous pouvez rapidement localiser toutes les soumissions dont les évaluations sont en retard, celles se trouvant à une étape spécifique du processus éditorial, ou celles soumises pour une rubrique particulière.
+Cliquez sur le bouton **Filtres** pour déployer l’ensemble des filtres de recherche. Les rédacteurs et rédactrice peuvent rapidement repérer toutes les soumissions dont les évaluations sont en retard, celles se trouvant à une étape spécifique du processus éditorial, ou celles soumises pour une rubrique particulière. Les directeurs et directrices de revues peuvent repérer les soumissions assignées à un rédacteur ou une rédactrice spécifique.

--- a/fr/tasks.md
+++ b/fr/tasks.md
@@ -4,4 +4,4 @@ Le menu « Tâches » vous offre un accès rapide aux mises à jour et aux tâ
 
 Vous pouvez cliquer sur le lien « Tâches » en haut de page pour visualiser ou supprimer toute tâche en attente.
 
-Pour plus d'informations, veuillez consulter [Learning OJS 3: Tasks](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow#tasks) (en anglais).
+Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Tâches](https://docs.pkp.sfu.ca/learning-ojs/fr/editorial-workflow#t%C3%A2ches).

--- a/fr/tools.md
+++ b/fr/tools.md
@@ -11,7 +11,7 @@ Les outils à votre disposition peuvent dépendre des plugiciels configurés par
  
 La fonction « Importer/Exporter » vous permet de déplacer du contenu entre des instances OJS. Vous pouvez importer et exporter des utilisateurs et utilisatrices, des publications et des métadonnées d'articles.
  
-Pour plus d'informations, veuillez consulter [Learning OJS 3: Import/Export](https://docs.pkp.sfu.ca/learning-ojs/en/tools#importexport) (en anglais).
+Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Importer/Exporter](https://docs.pkp.sfu.ca/learning-ojs/fr/tools#importerexporter).
 
 ## <a name="statistics"></a>Générateur de rapports
  
@@ -19,4 +19,4 @@ Le système génère des rapports sur l’utilisation du site et les soumissions
  
 Vous pouvez générer des rapports détaillés personnalisés et filtrer selon des paramètres complexes. Si vous n’êtes pas convaincus par un des paramètres, contactez votre support technique pour obtenir de l’aide.
 
-Pour plus d'informations, veuillez consulter [Learning OJS 3: Report Generator](https://docs.pkp.sfu.ca/learning-ojs/en/tools#report-generator) (en anglais).
+Pour plus d'informations, veuillez consulter [Apprendre OJS 3: Générateur de rapports ](https://docs.pkp.sfu.ca/learning-ojs/fr/tools#g%C3%A9n%C3%A9rateur-de-rapports).

--- a/fr/users-and-roles.md
+++ b/fr/users-and-roles.md
@@ -2,6 +2,7 @@
 
 1. [Utilisateurs-trices](users-and-roles#users-users)
 1. [Rôles](users-and-roles#users-roles)
+1. [Notification](users-and-roles#notify)
 1. [Options d'accès au site](users-and-roles#users-site-access)
 
 Gérez les utilisateurs et utilisatrices de la revue, assignez-leur des rôles et créez ou éditez des rôles existants.
@@ -31,6 +32,10 @@ Vous pouvez modifier ou supprimer des rôles existants, ou ajouter de nouveaux r
 - *Les rédacteurs et réadactrices* ainsi que les *assistants et assistantes* n’ont accès qu'aux étapes du [flux des travaux](editorial-workflow) assignées à leur rôle.
  
 En plus des divers niveaux d’autorisation, vous pouvez restreindre certains rôles à des étapes particulières du [flux des travaux](editorial-workflow). Cette fonctionnalité est pratique pour les professionnels et professionnelles qui peuvent n'avoir à intervenir que durant une ou deux étapes du processus, telles que la révision ou la mise en page.
+
+## <a name="notify"></a>Avis
+
+Si un administrateur ou une administratrice a activé l'envoi de courriels en lot dans les [Paramètres du site](https://docs.pkp.sfu.ca/learning-ojs/fr/site-administration#param%C3%A8tres-du-site), un onglet Avis sera visible. Vous pourrez utiliser cet onglet afin d'envoyer des courriels [par rôles](https://docs.pkp.sfu.ca/learning-ojs/fr/users-and-roles#utilisateurs-demail).
 
 ## <a name="site-access"></a>Options d'accès au site
 


### PR DESCRIPTION
This pull request does three things:

1. Updating the fr_CA version of the OJS manual to reflect the changes made for the 3.3. release.
2. Changing the links to the [Learning Guide](https://docs.pkp.sfu.ca/learning-ojs/en) to French labels and URLs.
3. Correcting a few translation errors.

File have been tested in a 3.3.0-5 instance.
 